### PR TITLE
Removing unused attributes from solver quote

### DIFF
--- a/apps/sdk-demo/src/views/demo/components/select-quote.tsx
+++ b/apps/sdk-demo/src/views/demo/components/select-quote.tsx
@@ -20,7 +20,6 @@ export default function SelectQuote({ intent, quotes, onQuoteSelected }: Props) 
           {quotes.map((quote) => (
             <div key={quote.receiveSignedIntentUrl} className="p-2 border-1 flex flex-col">
               <span>Quote from {quote.receiveSignedIntentUrl}</span>
-              <span>IntentSource Contract: {quote.intentSourceContract}</span>
               <span>Amounts requested by solver on the origin chain:</span>
               <ul className="list-disc">
                 {quote.quoteData.tokens.map((token) => (

--- a/apps/sdk-demo/src/views/demo/components/select-quote.tsx
+++ b/apps/sdk-demo/src/views/demo/components/select-quote.tsx
@@ -17,9 +17,8 @@ export default function SelectQuote({ intent, quotes, onQuoteSelected }: Props) 
       <span className="text-2xl">Quotes Available:</span>
       <div className="grid grid-cols-2 gap-4">
         <div className="flex flex-col gap-2">
-          {quotes.map((quote) => (
-            <div key={quote.receiveSignedIntentUrl} className="p-2 border-1 flex flex-col">
-              <span>Quote from {quote.receiveSignedIntentUrl}</span>
+          {quotes.map((quote, index) => (
+            <div key={`quote-${index}`} className="p-2 border-1 flex flex-col">
               <span>Amounts requested by solver on the origin chain:</span>
               <ul className="list-disc">
                 {quote.quoteData.tokens.map((token) => (

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -137,7 +137,7 @@ The SDK gives you what you need so that you can publish the intent to the origin
 ``` ts
 import { createWalletClient, privateKeyToAccount, webSocket, http, erc20Abi } from 'viem';
 import { optimism } from 'viem/chains';
-import { IntentSourceAbi } from '@eco-foundation/routes-ts';
+import { IntentSourceAbi, EcoProtocolAddresses } from '@eco-foundation/routes-ts';
 
 const account = privateKeyToAccount('YOUR PRIVATE KEY HERE')
 const originChain = optimism;
@@ -152,6 +152,8 @@ const originPublicClient = createPublicClient({
   transport: webSocket(rpcUrl) // OR http(rpcUrl)
 })
 
+const intentSourceContract = EcoProtocolAddresses[routesService.getEcoChainId(originChain.id)].IntentSource;
+
 try {
   // approve the quoted amount to account for fees
   await Promise.all(intentWithQuote.reward.tokens.map(async ({ token, amount }) => {
@@ -159,7 +161,7 @@ try {
       abi: erc20Abi,
       address: token,
       functionName: 'approve',
-      args: [selectedQuote.intentSourceContract, amount],
+      args: [intentSourceContract, amount],
       chain: originChain,
       account
     })
@@ -169,7 +171,7 @@ try {
 
   const publishTxHash = await originWalletClient.writeContract({
     abi: IntentSourceAbi,
-    address: selectedQuote.intentSourceContract,
+    address: intentSourceContract,
     functionName: 'publishAndFund',
     args: [intentWithQuote],
     chain: originChain,
@@ -184,13 +186,6 @@ catch (error) {
 ```
 
 [See more from viem's docs](https://viem.sh/)
-
-> **Note:** A quote will provide the address of an IntentSource contract for you, but if you aren't using a quote you can get the default IntentSource contract like so:
-``` ts
-import { EcoProtocolAddresses } from '@eco-foundation/routes-ts';
-
-const intentSourceContract = EcoProtocolAddresses[routesService.getEcoChainId(originChainID)].IntentSource;
-```
 
 # Full Demo
 

--- a/packages/sdk/src/quotes/types.ts
+++ b/packages/sdk/src/quotes/types.ts
@@ -41,7 +41,6 @@ export namespace OpenQuotingAPI {
 }
 
 export type SolverQuote = {
-  receiveSignedIntentUrl: string,
   quoteData: QuoteData
 }
 

--- a/packages/sdk/src/quotes/types.ts
+++ b/packages/sdk/src/quotes/types.ts
@@ -42,7 +42,6 @@ export namespace OpenQuotingAPI {
 
 export type SolverQuote = {
   receiveSignedIntentUrl: string,
-  intentSourceContract: Hex,
   quoteData: QuoteData
 }
 

--- a/packages/sdk/test/integration/OpenQuotingClient.test.ts
+++ b/packages/sdk/test/integration/OpenQuotingClient.test.ts
@@ -42,7 +42,6 @@ describe("OpenQuotingClient", () => {
       expect(quotes.length).toBeGreaterThan(0);
 
       for (const quote of quotes) {
-        expect(quote.receiveSignedIntentUrl).toBeDefined();
         expect(quote.quoteData).toBeDefined();
         expect(quote.quoteData.expiryTime).toBeDefined();
         expect(quote.quoteData.tokens).toBeDefined();
@@ -65,7 +64,6 @@ describe("OpenQuotingClient", () => {
       expect(quotes.length).toBeGreaterThan(0);
 
       for (const quote of quotes) {
-        expect(quote.receiveSignedIntentUrl).toBeDefined();
         expect(quote.quoteData).toBeDefined();
         expect(quote.quoteData.expiryTime).toBeDefined();
         expect(quote.quoteData.tokens).toBeDefined();

--- a/packages/sdk/test/integration/OpenQuotingClient.test.ts
+++ b/packages/sdk/test/integration/OpenQuotingClient.test.ts
@@ -43,7 +43,6 @@ describe("OpenQuotingClient", () => {
 
       for (const quote of quotes) {
         expect(quote.receiveSignedIntentUrl).toBeDefined();
-        expect(quote.intentSourceContract).toBeDefined();
         expect(quote.quoteData).toBeDefined();
         expect(quote.quoteData.expiryTime).toBeDefined();
         expect(quote.quoteData.tokens).toBeDefined();
@@ -67,7 +66,6 @@ describe("OpenQuotingClient", () => {
 
       for (const quote of quotes) {
         expect(quote.receiveSignedIntentUrl).toBeDefined();
-        expect(quote.intentSourceContract).toBeDefined();
         expect(quote.quoteData).toBeDefined();
         expect(quote.quoteData.expiryTime).toBeDefined();
         expect(quote.quoteData.tokens).toBeDefined();

--- a/packages/sdk/test/unit/RoutesService.test.ts
+++ b/packages/sdk/test/unit/RoutesService.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeAll, beforeEach } from "vitest";
 import { encodeFunctionData, erc20Abi, Hex, isAddress, zeroAddress } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { EcoProtocolAddresses, IntentType } from "@eco-foundation/routes-ts";
+import { IntentType } from "@eco-foundation/routes-ts";
 
 import { RoutesService, SolverQuote } from "../../src";
 import { dateToTimestamp, getSecondsFromNow } from "../../src/utils";
@@ -652,7 +652,6 @@ describe("RoutesService", () => {
 
     beforeEach(() => {
       validQuote = {
-        receiveSignedIntentUrl: "https://example.com/endpoint",
         quoteData: {
           tokens: [{
             token: RoutesService.getStableAddress(10, "USDC"),

--- a/packages/sdk/test/unit/RoutesService.test.ts
+++ b/packages/sdk/test/unit/RoutesService.test.ts
@@ -653,7 +653,6 @@ describe("RoutesService", () => {
     beforeEach(() => {
       validQuote = {
         receiveSignedIntentUrl: "https://example.com/endpoint",
-        intentSourceContract: EcoProtocolAddresses[10].IntentSource,
         quoteData: {
           tokens: [{
             token: RoutesService.getStableAddress(10, "USDC"),


### PR DESCRIPTION
Removing `intentSourceContract` and `receiveSignedIntentUrl` from solver quote type, updating docs