### PR TITLE
Add USDT0 - v1.12.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11960,7 +11960,7 @@
     },
     "packages/sdk": {
       "name": "@eco-foundation/routes-sdk",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eco-foundation/routes-sdk",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "Eco Routes SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/sdk/src/constants/index.ts
+++ b/packages/sdk/src/constants/index.ts
@@ -14,7 +14,7 @@ export const chainIds = [
 ] as const;
 export type RoutesSupportedChainId = typeof chainIds[number];
 
-export const stables = ["USDC", "USDbC", "USDCe", "USDT", "oUSDT"] as const;
+export const stables = ["USDC", "USDbC", "USDCe", "USDT", "oUSDT", 'USDT0'] as const;
 export type RoutesSupportedStable = typeof stables[number];
 
 export const stableAddresses: Record<RoutesSupportedChainId, Partial<Record<RoutesSupportedStable, Hex | undefined>>> = {
@@ -31,7 +31,7 @@ export const stableAddresses: Record<RoutesSupportedChainId, Partial<Record<Rout
   },
   130: {
     USDC: "0x078D782b760474a361dDA0AF3839290b0EF57AD6",
-    USDT: "0x588CE4F028D8e7B53B687865d6A67b3A54C75518"
+    USDT0: "0x9151434b16b9763660705744891fa906f660ecc5"
   },
   137: {
     USDC: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
@@ -62,6 +62,6 @@ export const stableAddresses: Record<RoutesSupportedChainId, Partial<Record<Rout
   },
   57073: {
     USDC: "0xF1815bd50389c46847f0Bda824eC8da914045D14",
-    USDT: "0x0200C29006150606B650577BBE7B6248F58470c1",
+    USDT0: "0x0200C29006150606B650577BBE7B6248F58470c1",
   }
 }


### PR DESCRIPTION
This pull request introduces a version bump for the `@eco-foundation/routes-sdk` package and updates the stablecoin constants to include a new token, `USDT0`, along with its associated addresses for specific chain IDs. These changes ensure compatibility with the new token across the SDK.

### Package version update:
* [`packages/sdk/package.json`](diffhunk://#diff-77164cc5c071d1488e1cf72c0f91fdd99dd8976edb5004c83198bbd517039572L3-R3): Updated the package version from `0.12.6` to `0.12.7` to reflect the new changes.

### Stablecoin constants update:
* [`packages/sdk/src/constants/index.ts`](diffhunk://#diff-53f1258ecbef401e828c0ab5de30398a9f19eaadbc589bc2760607b639b6f931L17-R17): Added `USDT0` to the `stables` array, expanding the list of supported stablecoins.
* [`packages/sdk/src/constants/index.ts`](diffhunk://#diff-53f1258ecbef401e828c0ab5de30398a9f19eaadbc589bc2760607b639b6f931L34-R34): Updated the `stableAddresses` object to include the address for `USDT0` on chain ID `130`.
* [`packages/sdk/src/constants/index.ts`](diffhunk://#diff-53f1258ecbef401e828c0ab5de30398a9f19eaadbc589bc2760607b639b6f931L65-R65): Updated the `stableAddresses` object to include the address for `USDT0` on chain ID `57073`, replacing the previous `USDT` entry.